### PR TITLE
bump caddy version to v2.6.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/caddy-dns/acmedns
 go 1.18
 
 require (
-	github.com/caddyserver/caddy/v2 v2.6.3
+	github.com/caddyserver/caddy/v2 v2.6.4
 	github.com/libdns/acmedns v0.2.0
 )
 


### PR DESCRIPTION
this fixes the following xcaddy build panic:
    2023/06/28 22:58:57 [INFO] exec (timeout=-2562047h47m16.854775808s): /usr/lib/go-1.19/bin/go get -d -v github.com/caddy-dns/acmedns@v0.2.0 github.com/caddyserver/caddy/v2@v2.6.4
    panic: internal error: can't find reason for requirement on github.com/google/pprof@v0.0.0-20210407192527-94a9f03dee38