### PR TITLE
support placeholders for password fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then follow these steps:
 	tls {
 		dns acmedns {
 			username <username you obtained in step 1>
-			password <password you obtained in step 1>
+			password <password you obtained in step 1> # supports Caddy placeholders
 			subdomain <ACME-DNS subdomain you obtained in step 1>
 			server_url <ACME-DNS server API URL>   # e.g. https://auth.acme-dns.io
 		}
@@ -140,7 +140,7 @@ You can also embed this into `Caddyfile` directly. If you want this configuratio
 		config {
 			your-domain-1.example.com {
 				username <username>
-				password <password>
+				password <password> # supports Caddy placeholders
 				subdomain <subdomain>
 				server_url <server url>
 

--- a/module.go
+++ b/module.go
@@ -31,6 +31,14 @@ func (Provider) CaddyModule() caddy.ModuleInfo {
 // Provision sets up the module. Implements caddy.Provisioner.
 func (p *Provider) Provision(ctx caddy.Context) error {
 	if p.ConfigFilePath == "" {
+		repl := caddy.NewReplacer()
+		if p.Configs != nil {
+			for _, config := range p.Configs {
+				config.Password = repl.ReplaceAll(config.Password, "")
+			}
+		} else {
+			p.Password = repl.ReplaceAll(p.Password, "")
+		}
 		return nil
 	}
 	file, err := ioutil.ReadFile(p.ConfigFilePath)


### PR DESCRIPTION
Caddy allows injection of values into configuration with its placeholders feature. This adds placeholder support to the password field when configured with the Caddyfile strategy. With this change, ACME DNS passwords can be supplied through environment variables or even separate files.

The implementation was guided by https://caddyserver.com/docs/extending-caddy/placeholders.